### PR TITLE
Issue Solved: Create a clickable icon on student answers

### DIFF
--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -133,6 +133,12 @@ define('forum/topic/postTools', [
 			return votes.toggleVote($(this), '.upvoted', 1);
 		});
 
+		postContainer.on('click', '[component="post/endorse"], [component="post/endrose"]', function (e) {
+			e.preventDefault();
+			console.log('The endorse button is under development. Please use upvote instead.');
+			alerts.info('The endorse button is under development. Please use upvote instead.');
+		});
+
 		postContainer.on('click', '[component="post/downvote"]', function () {
 			return votes.toggleVote($(this), '.downvoted', -1);
 		});

--- a/vendor/nodebb-theme-harmony-2.1.15/public/endorse-toggle-temp.js
+++ b/vendor/nodebb-theme-harmony-2.1.15/public/endorse-toggle-temp.js
@@ -1,0 +1,28 @@
+/* Temporary front-end-only toggle for the endorse button
+ * - Toggles `.endorsed` on the clicked `[component="post/endrose"]` anchor
+ * - Toggles `.has-endorsed` on the nearest `[component="post"]` wrapper
+ * - Does not persist to server; purely visual for demo/testing.
+ */
+
+(function () {
+	'use strict';
+
+	// Use delegated listener since posts are dynamic
+	$(document).on('click', '[component="post/endrose"]', function (ev) {
+		ev.preventDefault();
+		var $btn = $(this);
+		// Toggle endorsed class on the button
+		$btn.toggleClass('endorsed');
+		// Swap icon classes (text-success / text-muted)
+		var $icon = $btn.find('i.fa-thumbs-up');
+		if ($btn.hasClass('endorsed')) {
+			$icon.removeClass('text-muted').addClass('text-success');
+			// Add has-endorsed to nearest post wrapper so CSS fallback works
+			$btn.closest('[component="post"]').addClass('has-endorsed');
+		} else {
+			$icon.removeClass('text-success').addClass('text-muted');
+			$btn.closest('[component="post"]').removeClass('has-endorsed');
+		}
+	});
+
+})();

--- a/vendor/nodebb-theme-harmony-2.1.15/public/harmony.js
+++ b/vendor/nodebb-theme-harmony-2.1.15/public/harmony.js
@@ -295,4 +295,9 @@ $(document).ready(function () {
 		mainNavEl.on('shown.bs.dropdown', toggleOverflow)
 			.on('hidden.bs.dropdown', toggleOverflow);
 	}
+
+	// Load temporary front-end-only endorse toggle (purely visual/demo)
+	require(['./endorse-toggle-temp'], function () {
+		// module loads and self-initializes
+	});
 });

--- a/vendor/nodebb-theme-harmony-2.1.15/scss/topic.scss
+++ b/vendor/nodebb-theme-harmony-2.1.15/scss/topic.scss
@@ -126,6 +126,25 @@ body.template-topic {
 					opacity: 0;
 					transition: $transition-fade;
 
+					// If the actions container itself contains an endorsed button, show it
+					// Uses :has() (supported in modern browsers). See fallback below for
+					// older browsers — the template can add a `.has-endorsed` class to
+					// the post element when `posts.endorsed` is true.
+					&:has([component="post/endrose"].endorsed) {
+						opacity: 1;
+
+						// Make only the endorse button visible; hide other action buttons
+						> .post-tools > * {
+							opacity: 0;
+							pointer-events: none;
+						}
+						> .post-tools > [component="post/endrose"],
+						> .post-tools > [component="post/endrose"] * {
+							opacity: 1;
+							pointer-events: auto;
+						}
+					}
+
 					&:has([aria-expanded="true"]) {
 						opacity: 1;
 					}
@@ -136,6 +155,27 @@ body.template-topic {
 				&:hover {
 					> div > .post-container > [component="post/footer"] > div > [component="post/actions"] {
 						opacity: 1;
+					}
+				}
+
+				// Fallback for browsers without :has(): if the template adds
+				// `class="has-endorsed"` to the `[component="post"]` element when
+				// the post is endorsed, this will also force the actions to be
+				// visible. (Template-only solution; no JS required.)
+				&.has-endorsed {
+					> div > .post-container > [component="post/footer"] > div > [component="post/actions"] {
+						opacity: 1;
+
+						// Show only the endorse button for the fallback method too
+						> .post-tools > * {
+							opacity: 0;
+							pointer-events: none;
+						}
+						> .post-tools > [component="post/endrose"],
+						> .post-tools > [component="post/endrose"] * {
+							opacity: 1;
+							pointer-events: auto;
+						}
 					}
 				}
 			}

--- a/vendor/nodebb-theme-harmony-2.1.15/scss/topic.scss
+++ b/vendor/nodebb-theme-harmony-2.1.15/scss/topic.scss
@@ -123,6 +123,7 @@ body.template-topic {
 		.topic .posts {
 			[component="post"] {
 				[component="post/actions"] {
+					
 					opacity: 0;
 					transition: $transition-fade;
 
@@ -131,18 +132,8 @@ body.template-topic {
 					// older browsers — the template can add a `.has-endorsed` class to
 					// the post element when `posts.endorsed` is true.
 					&:has([component="post/endrose"].endorsed) {
-						opacity: 1;
-
-						// Make only the endorse button visible; hide other action buttons
-						> .post-tools > * {
-							opacity: 0;
-							pointer-events: none;
-						}
-						> .post-tools > [component="post/endrose"],
-						> .post-tools > [component="post/endrose"] * {
-							opacity: 1;
-							pointer-events: auto;
-						}
+						opacity: 0;
+						transition: $transition-fade;
 					}
 
 					&:has([aria-expanded="true"]) {
@@ -151,11 +142,6 @@ body.template-topic {
 				}
 				[component="post/actions"]:focus-within {
 					opacity: 1;
-				}
-				&:hover {
-					> div > .post-container > [component="post/footer"] > div > [component="post/actions"] {
-						opacity: 1;
-					}
 				}
 
 				// Fallback for browsers without :has(): if the template adds
@@ -166,13 +152,54 @@ body.template-topic {
 					> div > .post-container > [component="post/footer"] > div > [component="post/actions"] {
 						opacity: 1;
 
-						// Show only the endorse button for the fallback method too
-						> .post-tools > * {
+						// Fallback: hide direct action anchors except endorse, keep votes
+						> a:not([component="post/endrose"]) {
 							opacity: 0;
-							pointer-events: none;
+							pointer-events: auto;
 						}
-						> .post-tools > [component="post/endrose"],
-						> .post-tools > [component="post/endrose"] * {
+						> .votes {
+							opacity: 1;
+							pointer-events: auto;
+						}
+						> .votes a:not([component="post/endrose"]) {
+							opacity: 0;
+							pointer-events: auto;
+						}
+						[component="post/endrose"],
+						[component="post/endrose"] * {
+							opacity: 1;
+							pointer-events: auto;
+						}
+
+						// Hover fallback: when the post or actions area is hovered, restore
+						// non-endorse anchors to their normal interactive state.
+						> div > .post-container > [component="post/footer"] > div > [component="post/actions"]:hover > a:not([component="post/endrose"]),
+						> div > .post-container > [component="post/footer"] > div > [component="post/actions"] > .votes:hover a:not([component="post/endrose"]){
+							opacity: 1;
+							pointer-events: auto;
+						}
+					}
+				}
+
+				&:hover {
+					> div > .post-container > [component="post/footer"] > div > [component="post/actions"] {
+						opacity: 1;
+						transition: $transition-fade;
+
+						> a:not([component="post/endrose"]) {
+							opacity: 1;
+							pointer-events: auto;
+						}
+						> .votes {
+							opacity: 1;
+							pointer-events: auto;
+						}
+						> .votes a:not([component="post/endrose"]) {
+							opacity: 1;
+							pointer-events: auto;
+						}
+						[component="post/endrose"],
+						[component="post/endrose"] * {
 							opacity: 1;
 							pointer-events: auto;
 						}

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
@@ -130,6 +130,14 @@
 						<a component="post/downvote" href="#" class="btn btn-ghost btn-sm{{{ if posts.downvoted }}} downvoted{{{ end }}}" title="[[topic:downvote-post]]">
 							<i class="fa fa-fw fa-chevron-down text-primary"></i>
 						</a>
+
+						<a component="post/endrose" href="#" class="btn btn-ghost btn-sm{{{ if posts.endorsed }}} endorsed{{{ end }}}" title="Endorse Post" aria-label="[[topic:endorse-post]]">
+							{{{ if posts.endorsed }}}
+							<i class="fa fa-fw fa-thumbs-up text-success" aria-hidden="true"></i>
+							{{{ else }}}
+							<i class="fa fa-fw fa-thumbs-up text-muted" aria-hidden="true"></i>
+							{{{ end }}}
+						</a>
 						{{{ end }}}
 					</div>
 					{{{ end }}}


### PR DESCRIPTION
## Initial task: 
Create a clickable icon on the front end that calls a function on the backend that adjusts "endorsement" parameters on that specific student answer.

### Milestones Reached:

- [x] Choose icon for button
- [x] Place icon on clickable button on student answers
- [x] Link the button to a function call 
- [ ] Modifies the database so that specific student answer gets endorsed. (Was left for backend issue)

### Acceptance:

- User can see the endorse button
- Button is clickable and changes color to indicate endorsement

## Files Modified:

- public/src/client/topic/postTools.js
- vendor/nodebb-theme-harmony-2.1.15/public/harmony.js
- vendor/nodebb-theme-harmony-2.1.15/scss/topic.scss
- vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl

## Files Created:

- vendor/nodebb-theme-harmony-2.1.15/public/endorse-toggle-temp.js (temporary js file for button functionality showcase)

## Issue resolved