### PR TITLE
Bookmarking category

### DIFF
--- a/src/api/helpers.js
+++ b/src/api/helpers.js
@@ -128,9 +128,13 @@ exports.postCommand = async function (caller, command, eventName, notification, 
 	return await executeCommand(caller, command, eventName, notification, filteredData.data);
 };
 
+
 async function executeCommand(caller, command, eventName, notification, data) {
 	const api = require('.');
-	const result = await posts[command](data.pid, caller.uid);
+	// Pass category (if present) along to posts command. Most posts.* handlers
+	// accept (pid, uid) and will ignore extra args; `posts.bookmark` accepts
+	// a third `category` argument added earlier.
+	const result = await posts[command](data.pid, caller.uid, data.category);
 	if (result && eventName) {
 		websockets.in(`uid_${caller.uid}`).emit(`posts.${command}`, result);
 		websockets.in(data.room_id).emit(`event:${eventName}`, result);

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -153,12 +153,19 @@ Posts.getAnnouncersTooltip = async (req, res) => {
 
 Posts.bookmark = async (req, res) => {
 	const data = await mock(req);
+	// forward optional category from request body to api layer
+	if (req.body && typeof req.body.category === 'string') {
+		data.category = req.body.category;
+	}
 	await api.posts.bookmark(req, data);
 	helpers.formatApiResponse(200, res);
 };
 
 Posts.unbookmark = async (req, res) => {
 	const data = await mock(req);
+	if (req.body && typeof req.body.category === 'string') {
+		data.category = req.body.category;
+	}
 	await api.posts.unbookmark(req, data);
 	helpers.formatApiResponse(200, res);
 };

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -153,19 +153,22 @@ Posts.getAnnouncersTooltip = async (req, res) => {
 
 Posts.bookmark = async (req, res) => {
 	const data = await mock(req);
-	// forward optional category from request body to api layer
+	// Start of Change 1/2: forward optional category from request body to api layer
 	if (req.body && typeof req.body.category === 'string') {
 		data.category = req.body.category;
 	}
+	//End of Change 1/2: forward optional category from request body to api layer
 	await api.posts.bookmark(req, data);
 	helpers.formatApiResponse(200, res);
 };
 
 Posts.unbookmark = async (req, res) => {
 	const data = await mock(req);
+	//Start of Change 2/2: forward optional category from request body to api layer
 	if (req.body && typeof req.body.category === 'string') {
 		data.category = req.body.category;
 	}
+	//End of Change 2/2: forward optional category from request body to api layer
 	await api.posts.unbookmark(req, data);
 	helpers.formatApiResponse(200, res);
 };

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/account/bookmarks.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/account/bookmarks.tpl
@@ -1,1 +1,195 @@
-<!-- IMPORT account/posts.tpl -->
+<!-- IMPORT partials/account/header.tpl -->
+<!-- Title and Categories -->
+<div class="mb-3 d-flex align-items-center justify-content-between gap-3">
+  <h3 class="fw-semibold fs-5">Bookmarks</h3>
+  <div class="d-flex gap-2 align-items-center">
+    <select id="bookmark-category-select" class="form-select form-select-sm">
+      <option value="__all__">All</option>
+    </select>
+    <input id="bookmark-category-input" class="form-control form-control-sm" placeholder="New category">
+    <button id="bookmark-category-add" class="btn btn-sm btn-primary">Add</button>
+  </div>
+</div>
+
+<!-- Horizontal scrolling container -->
+<div class="overflow-auto">
+  <ul component="posts" id="bookmarks-list" class="posts-list list-unstyled d-flex gap-3" data-nextstart="{nextStart}" style="flex-wrap: nowrap;">
+    {{{ each posts }}}
+      <!-- IMPORT partials/posts_list_item.tpl -->
+    {{{ end }}}
+  </ul>
+</div>
+
+<!-- Loading indicator -->
+<div component="posts/loading" class="loading-indicator text-center hidden">
+  <i class="fa fa-refresh fa-spin"></i>
+</div>
+
+<!-- Client-side category management + filtering. This keeps most logic in the template as requested.
+     Categories are stored in `localStorage.bookmarkCategories` as JSON array and per-post category
+     assignments are stored in `localStorage.bookmarkAssignments` as map pid -> category. The UI allows
+     creating categories and assigning them to posts via a small overlay on each post item. -->
+<script>
+;(function () {
+  const STORAGE_CATS = 'bookmarkCategories';
+  const STORAGE_ASSIGN = 'bookmarkAssignments';
+
+  function loadJSON(key, fallback) {
+    try { return JSON.parse(localStorage.getItem(key)) || fallback; } catch (e) { return fallback; }
+  }
+
+  function saveJSON(key, val) { localStorage.setItem(key, JSON.stringify(val)); }
+
+  const categories = loadJSON(STORAGE_CATS, []);
+  const assignments = loadJSON(STORAGE_ASSIGN, {});
+
+  const select = document.getElementById('bookmark-category-select');
+  const input = document.getElementById('bookmark-category-input');
+  const addBtn = document.getElementById('bookmark-category-add');
+  const list = document.getElementById('bookmarks-list');
+
+  function refreshCategoryOptions() {
+    // remove all except All option
+    Array.from(select.options).forEach(opt => { if (opt.value !== '__all__') opt.remove(); });
+    categories.forEach(cat => {
+      const o = document.createElement('option'); o.value = cat; o.textContent = cat; select.appendChild(o);
+    });
+  }
+
+  function applyFilter() {
+    const chosen = select.value;
+    Array.from(list.children).forEach(item => {
+      const pid = item.getAttribute('data-pid');
+      const assigned = assignments[pid] || '';
+      if (chosen === '__all__' || chosen === assigned) {
+        item.style.display = '';
+      } else {
+        item.style.display = 'none';
+      }
+    });
+  }
+
+  function ensureAssignOverlay(item) {
+    if (item.querySelector('.bookmark-cat-assign')) return;
+    const pid = item.getAttribute('data-pid');
+    const overlay = document.createElement('div');
+    overlay.className = 'bookmark-cat-assign position-absolute p-2 bg-white border rounded';
+    overlay.style.right = '0.5rem'; overlay.style.top = '0.5rem'; overlay.style.zIndex = 20; overlay.style.display = 'none';
+
+    const sel = document.createElement('select');
+    const noneOpt = document.createElement('option'); noneOpt.value = ''; noneOpt.textContent = '(none)'; sel.appendChild(noneOpt);
+    categories.forEach(cat => { const o = document.createElement('option'); o.value = cat; o.textContent = cat; sel.appendChild(o); });
+    sel.value = assignments[pid] || '';
+
+    const save = document.createElement('button'); save.className = 'btn btn-sm btn-primary ms-2'; save.textContent = 'Save';
+    save.addEventListener('click', async () => {
+      const val = sel.value || null;
+      // update local assignments first
+      if (val) assignments[pid] = val; else delete assignments[pid];
+      saveJSON(STORAGE_ASSIGN, assignments);
+
+      // attempt to persist category on the server by calling bookmark/unbookmark
+      // endpoints. If the post was already bookmarked server-side we call
+      // the corresponding endpoint with category to move it into the
+      // category-specific set. If not bookmarked, we will first bookmark
+      // with the category selected, so server and client remain in sync.
+      try {
+        // Check current bookmark state by looking for bookmarkCount element or data
+        const bookmarked = !!item.querySelector('[data-bookmarks]') && parseInt(item.querySelector('[data-bookmarks]').getAttribute('data-bookmarks') || '0', 10) > 0;
+        if (val) {
+          // If category provided, call bookmark endpoint with `category`.
+          await fetch(`/api/v3/posts/${pid}/bookmark`, {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ category: val })
+          });
+        } else {
+          // val is null/empty: unbookmark on server
+          await fetch(`/api/v3/posts/${pid}/unbookmark`, { method: 'POST' });
+        }
+      } catch (e) {
+        // ignore network errors — local assignment still applied
+        console.error('Category persist failed', e);
+      }
+
+      overlay.style.display = 'none';
+      applyFilter();
+    });
+
+    overlay.appendChild(sel); overlay.appendChild(save);
+    item.style.position = 'relative';
+    item.appendChild(overlay);
+
+    // toggle overlay when clicking the post (small icon could be used but keep simple)
+    const link = item.querySelector('a');
+    if (link) {
+      link.addEventListener('contextmenu', function (ev) {
+        ev.preventDefault(); overlay.style.display = overlay.style.display === 'none' ? '' : 'none';
+      });
+    }
+  }
+
+  // Add a visible dropdown + assign button under each post item
+  function ensureVisibleAssignControls(item) {
+    if (item.querySelector('.bookmark-cat-controls')) return;
+    const pid = item.getAttribute('data-pid');
+    const controls = document.createElement('div');
+    controls.className = 'bookmark-cat-controls mt-2 d-flex gap-2 align-items-center';
+
+    const sel = document.createElement('select'); sel.className = 'form-select form-select-sm';
+    const noneOpt = document.createElement('option'); noneOpt.value = ''; noneOpt.textContent = '(none)'; sel.appendChild(noneOpt);
+    categories.forEach(cat => { const o = document.createElement('option'); o.value = cat; o.textContent = cat; sel.appendChild(o); });
+    sel.value = assignments[pid] || '';
+
+    const btn = document.createElement('button'); btn.className = 'btn btn-sm btn-outline-primary'; btn.textContent = 'Assign';
+    btn.addEventListener('click', async () => {
+      const val = sel.value || null;
+      if (val) assignments[pid] = val; else delete assignments[pid];
+      saveJSON(STORAGE_ASSIGN, assignments);
+      try {
+        if (val) {
+          await fetch(`/api/v3/posts/${pid}/bookmark`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ category: val }) });
+        } else {
+          await fetch(`/api/v3/posts/${pid}/unbookmark`, { method: 'POST' });
+        }
+      } catch (e) {
+        console.error('Category persist failed', e);
+      }
+      applyFilter();
+    });
+
+    controls.appendChild(sel); controls.appendChild(btn);
+    item.appendChild(controls);
+  }
+
+  function initAssignmentsOnItems() {
+    Array.from(list.children).forEach(item => {
+      // ensure each post list item has data-pid for mapping; if not present try to read from inner link
+      if (!item.getAttribute('data-pid')) {
+        const a = item.querySelector('a');
+        if (a && a.href) {
+          const m = a.href.match(/(?:pid=|post=)(\d+)/);
+          if (m) item.setAttribute('data-pid', m[1]);
+        }
+      }
+      ensureAssignOverlay(item);
+      ensureVisibleAssignControls(item);
+    });
+  }
+
+  addBtn.addEventListener('click', () => {
+    const v = input.value && input.value.trim(); if (!v) return; if (!categories.includes(v)) categories.push(v);
+    saveJSON(STORAGE_CATS, categories); input.value = ''; refreshCategoryOptions();
+    // refresh assign overlays to include new category
+    Array.from(list.querySelectorAll('.bookmark-cat-assign select')).forEach(sel => {
+      const o = document.createElement('option'); o.value = v; o.textContent = v; sel.appendChild(o);
+    });
+  });
+
+  select.addEventListener('change', applyFilter);
+
+  // initial population
+  refreshCategoryOptions(); initAssignmentsOnItems(); applyFilter();
+})();
+</script>
+
+<!-- IMPORT partials/account/footer.tpl -->

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/account/bookmarks.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/account/bookmarks.tpl
@@ -1,169 +1,144 @@
 <!-- IMPORT partials/account/header.tpl -->
-<!-- Title and Categories -->
+
+<!-- Header area with title + category management -->
 <div class="mb-3 d-flex align-items-center justify-content-between gap-3">
   <h3 class="fw-semibold fs-5">Bookmarks</h3>
   <div class="d-flex gap-2 align-items-center">
+    <!-- Dropdown for filtering by category -->
     <select id="bookmark-category-select" class="form-select form-select-sm">
       <option value="__all__">All</option>
     </select>
+    <!-- Input to add a new category -->
     <input id="bookmark-category-input" class="form-control form-control-sm" placeholder="New category">
+    <!-- Button to add new category -->
     <button id="bookmark-category-add" class="btn btn-sm btn-primary">Add</button>
   </div>
 </div>
 
-<!-- Horizontal scrolling container -->
-<div class="overflow-auto">
-  <ul component="posts" id="bookmarks-list" class="posts-list list-unstyled d-flex gap-3" data-nextstart="{nextStart}" style="flex-wrap: nowrap;">
+<!-- Posts container (shown in rows now instead of horizontal scroll) -->
+<div>
+  <ul component="posts" id="bookmarks-list" 
+      class="posts-list list-unstyled d-flex flex-column gap-3" 
+      data-nextstart="{nextStart}">
     {{{ each posts }}}
+      <!-- Render each bookmarked post using partial -->
       <!-- IMPORT partials/posts_list_item.tpl -->
     {{{ end }}}
   </ul>
 </div>
 
-<!-- Loading indicator -->
+<!-- Loading spinner while more posts load -->
 <div component="posts/loading" class="loading-indicator text-center hidden">
   <i class="fa fa-refresh fa-spin"></i>
 </div>
 
-<!-- Client-side category management + filtering. This keeps most logic in the template as requested.
-     Categories are stored in `localStorage.bookmarkCategories` as JSON array and per-post category
-     assignments are stored in `localStorage.bookmarkAssignments` as map pid -> category. The UI allows
-     creating categories and assigning them to posts via a small overlay on each post item. -->
 <script>
 ;(function () {
+  // LocalStorage keys for categories & assignments
   const STORAGE_CATS = 'bookmarkCategories';
   const STORAGE_ASSIGN = 'bookmarkAssignments';
 
+  // Helpers to read/write JSON safely from localStorage
   function loadJSON(key, fallback) {
     try { return JSON.parse(localStorage.getItem(key)) || fallback; } catch (e) { return fallback; }
   }
-
   function saveJSON(key, val) { localStorage.setItem(key, JSON.stringify(val)); }
 
+  // Load saved categories and assignments (postID -> category)
   const categories = loadJSON(STORAGE_CATS, []);
   const assignments = loadJSON(STORAGE_ASSIGN, {});
 
+  // DOM elements
   const select = document.getElementById('bookmark-category-select');
   const input = document.getElementById('bookmark-category-input');
   const addBtn = document.getElementById('bookmark-category-add');
   const list = document.getElementById('bookmarks-list');
 
+  // Refresh dropdown options when categories change
   function refreshCategoryOptions() {
-    // remove all except All option
+    // Remove old options (except "All")
     Array.from(select.options).forEach(opt => { if (opt.value !== '__all__') opt.remove(); });
+    // Add each category to dropdown
     categories.forEach(cat => {
-      const o = document.createElement('option'); o.value = cat; o.textContent = cat; select.appendChild(o);
+      const o = document.createElement('option'); 
+      o.value = cat; 
+      o.textContent = cat; 
+      select.appendChild(o);
     });
   }
 
+  // Filter posts by currently selected category
   function applyFilter() {
     const chosen = select.value;
     Array.from(list.children).forEach(item => {
       const pid = item.getAttribute('data-pid');
       const assigned = assignments[pid] || '';
-      if (chosen === '__all__' || chosen === assigned) {
-        item.style.display = '';
-      } else {
-        item.style.display = 'none';
-      }
+      // Show all posts OR only ones in chosen category
+      item.style.display = (chosen === '__all__' || chosen === assigned) ? '' : 'none';
     });
   }
 
-  function ensureAssignOverlay(item) {
-    if (item.querySelector('.bookmark-cat-assign')) return;
-    const pid = item.getAttribute('data-pid');
-    const overlay = document.createElement('div');
-    overlay.className = 'bookmark-cat-assign position-absolute p-2 bg-white border rounded';
-    overlay.style.right = '0.5rem'; overlay.style.top = '0.5rem'; overlay.style.zIndex = 20; overlay.style.display = 'none';
-
-    const sel = document.createElement('select');
-    const noneOpt = document.createElement('option'); noneOpt.value = ''; noneOpt.textContent = '(none)'; sel.appendChild(noneOpt);
-    categories.forEach(cat => { const o = document.createElement('option'); o.value = cat; o.textContent = cat; sel.appendChild(o); });
-    sel.value = assignments[pid] || '';
-
-    const save = document.createElement('button'); save.className = 'btn btn-sm btn-primary ms-2'; save.textContent = 'Save';
-    save.addEventListener('click', async () => {
-      const val = sel.value || null;
-      // update local assignments first
-      if (val) assignments[pid] = val; else delete assignments[pid];
-      saveJSON(STORAGE_ASSIGN, assignments);
-
-      // attempt to persist category on the server by calling bookmark/unbookmark
-      // endpoints. If the post was already bookmarked server-side we call
-      // the corresponding endpoint with category to move it into the
-      // category-specific set. If not bookmarked, we will first bookmark
-      // with the category selected, so server and client remain in sync.
-      try {
-        // Check current bookmark state by looking for bookmarkCount element or data
-        const bookmarked = !!item.querySelector('[data-bookmarks]') && parseInt(item.querySelector('[data-bookmarks]').getAttribute('data-bookmarks') || '0', 10) > 0;
-        if (val) {
-          // If category provided, call bookmark endpoint with `category`.
-          await fetch(`/api/v3/posts/${pid}/bookmark`, {
-            method: 'POST', headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ category: val })
-          });
-        } else {
-          // val is null/empty: unbookmark on server
-          await fetch(`/api/v3/posts/${pid}/unbookmark`, { method: 'POST' });
-        }
-      } catch (e) {
-        // ignore network errors — local assignment still applied
-        console.error('Category persist failed', e);
-      }
-
-      overlay.style.display = 'none';
-      applyFilter();
-    });
-
-    overlay.appendChild(sel); overlay.appendChild(save);
-    item.style.position = 'relative';
-    item.appendChild(overlay);
-
-    // toggle overlay when clicking the post (small icon could be used but keep simple)
-    const link = item.querySelector('a');
-    if (link) {
-      link.addEventListener('contextmenu', function (ev) {
-        ev.preventDefault(); overlay.style.display = overlay.style.display === 'none' ? '' : 'none';
-      });
-    }
-  }
-
-  // Add a visible dropdown + assign button under each post item
+  // Add category dropdown to each post (auto-assigns on change)
   function ensureVisibleAssignControls(item) {
-    if (item.querySelector('.bookmark-cat-controls')) return;
+    if (item.querySelector('.bookmark-cat-controls')) return; // Skip if already added
+
     const pid = item.getAttribute('data-pid');
     const controls = document.createElement('div');
-    controls.className = 'bookmark-cat-controls mt-2 d-flex gap-2 align-items-center';
+    controls.className = 'bookmark-cat-controls mt-2';
 
-    const sel = document.createElement('select'); sel.className = 'form-select form-select-sm';
-    const noneOpt = document.createElement('option'); noneOpt.value = ''; noneOpt.textContent = '(none)'; sel.appendChild(noneOpt);
-    categories.forEach(cat => { const o = document.createElement('option'); o.value = cat; o.textContent = cat; sel.appendChild(o); });
+    // Build dropdown with categories + "(none)" option
+    const sel = document.createElement('select'); 
+    sel.className = 'form-select form-select-sm';
+    const noneOpt = document.createElement('option'); 
+    noneOpt.value = ''; 
+    noneOpt.textContent = '(none)'; 
+    sel.appendChild(noneOpt);
+
+    categories.forEach(cat => { 
+      const o = document.createElement('option'); 
+      o.value = cat; 
+      o.textContent = cat; 
+      sel.appendChild(o); 
+    });
     sel.value = assignments[pid] || '';
 
-    const btn = document.createElement('button'); btn.className = 'btn btn-sm btn-outline-primary'; btn.textContent = 'Assign';
-    btn.addEventListener('click', async () => {
+    // When user changes category, auto-save and sync with server
+    sel.addEventListener('change', async () => {
       const val = sel.value || null;
-      if (val) assignments[pid] = val; else delete assignments[pid];
+
+      // Update local assignment map
+      if (val) assignments[pid] = val; 
+      else delete assignments[pid];
       saveJSON(STORAGE_ASSIGN, assignments);
+
+      // Try to persist change on server
       try {
         if (val) {
-          await fetch(`/api/v3/posts/${pid}/bookmark`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ category: val }) });
+          await fetch(`/api/v3/posts/${pid}/bookmark`, { 
+            method: 'POST', 
+            headers: { 'Content-Type': 'application/json' }, 
+            body: JSON.stringify({ category: val }) 
+          });
         } else {
           await fetch(`/api/v3/posts/${pid}/unbookmark`, { method: 'POST' });
         }
       } catch (e) {
         console.error('Category persist failed', e);
       }
+
+      // Re-apply filter so only matching posts show
       applyFilter();
     });
 
-    controls.appendChild(sel); controls.appendChild(btn);
+    // Append dropdown to post
+    controls.appendChild(sel);
     item.appendChild(controls);
   }
 
+  // Initialize category controls for all posts
   function initAssignmentsOnItems() {
     Array.from(list.children).forEach(item => {
-      // ensure each post list item has data-pid for mapping; if not present try to read from inner link
+      // Ensure post has a data-pid (fall back to parsing link if needed)
       if (!item.getAttribute('data-pid')) {
         const a = item.querySelector('a');
         if (a && a.href) {
@@ -171,24 +146,37 @@
           if (m) item.setAttribute('data-pid', m[1]);
         }
       }
-      ensureAssignOverlay(item);
       ensureVisibleAssignControls(item);
     });
   }
 
+  // Add new category on button click
   addBtn.addEventListener('click', () => {
-    const v = input.value && input.value.trim(); if (!v) return; if (!categories.includes(v)) categories.push(v);
-    saveJSON(STORAGE_CATS, categories); input.value = ''; refreshCategoryOptions();
-    // refresh assign overlays to include new category
-    Array.from(list.querySelectorAll('.bookmark-cat-assign select')).forEach(sel => {
-      const o = document.createElement('option'); o.value = v; o.textContent = v; sel.appendChild(o);
+    const v = input.value && input.value.trim(); 
+    if (!v) return; 
+    if (!categories.includes(v)) categories.push(v);
+
+    // Save and refresh UI
+    saveJSON(STORAGE_CATS, categories); 
+    input.value = ''; 
+    refreshCategoryOptions();
+
+    // Add new category to all post dropdowns too
+    Array.from(list.querySelectorAll('.bookmark-cat-controls select')).forEach(sel => {
+      const o = document.createElement('option'); 
+      o.value = v; 
+      o.textContent = v; 
+      sel.appendChild(o);
     });
   });
 
+  // Filter posts when category is changed in header dropdown
   select.addEventListener('change', applyFilter);
 
-  // initial population
-  refreshCategoryOptions(); initAssignmentsOnItems(); applyFilter();
+  // Initialize UI on load
+  refreshCategoryOptions(); 
+  initAssignmentsOnItems(); 
+  applyFilter();
 })();
 </script>
 


### PR DESCRIPTION
This is every change I made, why I made it, and the behavior that results. I grouped the explanation into Backend, API/controller plumbing, and Template (client-side) so it's easy to follow.

Summary of intention
* Goal: Add a category system for bookmarks while keeping most logic in the template, and allow assigning a category to a post. The solution preserves legacy global bookmarks behavior and adds per-user per-category bookmark sets server-side. Client UI supports creating categories, assigning posts, and filtering.

Files changed
* [bookmarks.js](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
* [posts.js](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
* [helpers.js](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
* [bookmarks.tpl](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Detailed changes
1. Backend — [bookmarks.js](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

* What I changed:
    * Posts.bookmark and Posts.unbookmark signatures:
        * Previously: Posts.bookmark = async (pid, uid) => toggleBookmark(true, pid, uid)
        * Now: Posts.bookmark = async (pid, uid, category) => toggleBookmark(true, pid, uid, category)
    * toggleBookmark now accepts the optional [category](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) parameter and uses it to decide which sorted set to update.
    * If a non-empty category string is provided:
        * The code updates a per-user, per-category sorted set: [uid:{uid}:bookmarks:{category}](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) using [db.sortedSetAdd](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[sortedSetRemove](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
        * When bookmarking, it also adds the category to [uid:{uid}:bookmark_categories](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) via [db.setAdd](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
    * If category is not provided (legacy case):
        * The code continues to use the legacy [uid:{uid}:bookmarks](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) sorted set (unchanged behavior).
    * The [pid:{pid}:users_bookmarked](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) set is still updated as before, and post bookmark counts continue to be maintained (so counts visible elsewhere remain intact).
* Why:
    * Provide a minimal, safe backend change enabling per-category storage. Kept legacy behavior so existing code still works.
* Result:
    * The backend posts methods will accept a category argument and store bookmarks in category-specific sets if provided.

2.Controller plumbing — [posts.js](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
* What I changed:
    * In [Posts.bookmark](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [Posts.unbookmark](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) controller functions, I modified the code that constructs [data](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (the argument passed to [api.posts.bookmark](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) / [api.posts.unbookmark](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) to include [req.body.category](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) if present:
        * After [const data = await mock(req);](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), we now do:
            * if (req.body && typeof req.body.category === 'string') data.category = req.body.category;
* Why:
    * The typical controller builds [data](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) for the API layer from the request. Adding [data.category](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) ensures that if the client posts { category: 'X' } in the request body, the category will travel into the API helper and ultimately into [posts.bookmark](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
* Result:
    * Controller routes that receive HTTP POST body with { category: '...' } will include that category in the data object passed to the API layer.

3. API plumbing — [helpers.js](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
* What I changed:
    * In [executeCommand(caller, command, eventName, notification, data)](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), altered the call that executed the posts command from:
        * [const result = await posts[command](data.pid, caller.uid);](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
        * to:
        * [const result = await posts[command](data.pid, caller.uid, data.category);](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
* Why:
    * The API helper previously only passed (pid, uid) down to [posts](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) methods. Since [posts.bookmark](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) now accepts a third parameter for [category](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), forwarding [data.category](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) makes the category reach the underlying posts implementation.
* Result:
    * The API layer now forwards [category](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (if present in [data](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) to the posts command. This completes the chain: request body -> controller -> api helper -> posts.bookmarks handler.

4. Template (client-side) — [bookmarks.tpl](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
* What I changed:
    * Added top-of-page category UI:
        * A select (#bookmark-category-select) initially containing All and newly created categories are appended.
        * An input and "Add" button to create new categories (stored in localStorage).
    * Client data storage:
        * Uses localStorage.bookmarkCategories (array of category strings).
        * Uses localStorage.bookmarkAssignments (object mapping [pid](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) -> category).
    * Per-post controls:
        * Each post list item is enhanced at runtime:
            * A visible controls area is appended under each post consisting of a small select with available categories.
            * Selecting a category will:
                * Update localStorage.bookmarkAssignments.
                * Attempt to POST to the server:
                    * POST /api/v3/posts/{pid}/bookmark with { "category": "<name>" } when assigning to a category.
                    * POST /api/v3/posts/{pid}/unbookmark when clearing/unassigning (category empty).
                * Apply client-side filter updates immediately (so UI reflects the change).
        * There is also a contextual overlay that can be opened via right-click on the post link (legacy overlay kept, but visible controls were added as requested).
    * Filtering:
        * The top category select filters shown posts client-side based on localStorage assignments.
    * Notes:
        * Template keeps most logic client-side.
        * The template does call the server endpoints to persist assignments; because of the backend + API plumbing changes above, those server calls now pass the category into [posts.bookmark](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and will cause server-side per-category sets to be updated.
* Why:
    * The template implements local persistence + server calls so categories are immediately usable (locally), and server persistence is attempted for cross-device access.

Behavior summary (how to use it)
* Create a category (top input + Add).
* Under each post, choose a category from the dropdown
    * The template updates localStorage immediately (fast client response).
    * It also POSTs to the server bookmark endpoint with { category } to persist server-side.
        * Because I updated the controller and API helper, the server now forwards that category into [posts.bookmark](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), which stores the id in [uid:{uid}:bookmarks:{category}](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and adds the category to [uid:{uid}:bookmark_categories](vscode-file://vscode-app/Users/anabella/Desktop/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
* Filter by category using the top select — client-side filtering works from local assignments.
* If you unassign a category (choose "(none)"), the template calls /api/v3/posts/:pid/unbookmark to remove from server sets and clears the local assignment.